### PR TITLE
Fix/errorgraph config

### DIFF
--- a/config/public/gps_baro/hdg_hw_api.yaml
+++ b/config/public/gps_baro/hdg_hw_api.yaml
@@ -12,7 +12,3 @@ mrs_uav_managers:
         topics:
           orientation: "hw_api/orientation" # without uav namespace
           angular_velocity: "hw_api/angular_velocity" # without uav namespace
-
-        source: # which node of the system provides the corrections (for error reporting)
-          node: "HwApiManager"
-          component: "main"

--- a/config/public/gps_garmin/hdg_hw_api.yaml
+++ b/config/public/gps_garmin/hdg_hw_api.yaml
@@ -11,7 +11,3 @@ mrs_uav_managers:
         topics:
           orientation: "hw_api/orientation" # without uav namespace
           angular_velocity: "hw_api/angular_velocity" # without uav namespace
-
-        source: # which node of the system provides the corrections (for error reporting)
-          node: "HwApiManager"
-          component: "main"

--- a/config/public/rtk/hdg_hw_api.yaml
+++ b/config/public/rtk/hdg_hw_api.yaml
@@ -13,7 +13,3 @@ mrs_uav_managers:
           orientation: "hw_api/orientation" # without uav namespace
           angular_velocity: "hw_api/angular_velocity" # without uav namespace
 
-        source: # which node of the system provides the corrections (for error reporting)
-          node: "HwApiManager"
-          component: "main"
-

--- a/config/public/rtk_garmin/hdg_hw_api.yaml
+++ b/config/public/rtk_garmin/hdg_hw_api.yaml
@@ -13,7 +13,3 @@ mrs_uav_managers:
           orientation: "hw_api/orientation" # without uav namespace
           angular_velocity: "hw_api/angular_velocity" # without uav namespace
 
-        source: # which node of the system provides the corrections (for error reporting)
-          node: "HwApiManager"
-          component: "main"
-

--- a/include/mrs_uav_state_estimators/estimators/correction.h
+++ b/include/mrs_uav_state_estimators/estimators/correction.h
@@ -327,8 +327,8 @@ Correction<n_measurements>::Correction(const rclcpp::Node::SharedPtr &node, cons
   msg_delay_warn_limit_ = msg_delay_limit_ / 2; // maybe specify this as a param?
   ph->param_loader->loadParam("message/limit/time_since_last", time_since_last_msg_limit_);
 
-  ph->param_loader->loadParam("source/node", source_node_id_.node);
-  ph->param_loader->loadParam("source/component", source_node_id_.component);
+  ph->param_loader->loadParam("source/node", source_node_id_.node, std::string("HwApiManager"));
+  ph->param_loader->loadParam("source/component", source_node_id_.component, std::string("main"));
 
   int state_id_tmp;
   ph->param_loader->loadParam("state_id", state_id_tmp);

--- a/include/mrs_uav_state_estimators/estimators/heading/hdg_passthrough.h
+++ b/include/mrs_uav_state_estimators/estimators/heading/hdg_passthrough.h
@@ -70,7 +70,6 @@ private:
   };
 
   std::unique_ptr<mrs_lib::errorgraph::ErrorPublisher> error_publisher_;
-  mrs_lib::errorgraph::node_id_t                       source_node_id_;
 
   std::string                                                       orient_topic_;
   mrs_lib::SubscriberHandler<geometry_msgs::msg::QuaternionStamped> sh_orientation_;
@@ -88,8 +87,6 @@ private:
 
   std::shared_ptr<TimerType> timer_check_health_;
   void                       timerCheckHealth();
-
-  mrs_lib::errorgraph::node_id_t getSourceNodeId() const;
 
 public:
   HdgPassthrough(const std::string &name, const std::string &ns_frame_id, const std::string &parent_state_est_name, const bool is_core_plugin)

--- a/src/estimators/heading/hdg_passthrough.cpp
+++ b/src/estimators/heading/hdg_passthrough.cpp
@@ -54,9 +54,6 @@ void HdgPassthrough::initialize(const rclcpp::Node::SharedPtr &node, const std::
   ph->param_loader->loadParam("topics/orientation", orient_topic_);
   ph->param_loader->loadParam("topics/angular_velocity", ang_vel_topic_);
 
-  ph->param_loader->loadParam("source/node", source_node_id_.node);
-  ph->param_loader->loadParam("source/component", source_node_id_.component);
-
   if (!ph->param_loader->loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "[%s]: Could not load all non-optional parameters. Shutting down.", getPrintName().c_str());
     rclcpp::shutdown();
@@ -351,12 +348,6 @@ std::string HdgPassthrough::getNamespacedName() const {
 /*//{ getPrintName() */
 std::string HdgPassthrough::getPrintName() const {
   return parent_state_est_name_ + "/" + getName();
-}
-/*//}*/
-
-/*//{ getSourceNodeId() */
-mrs_lib::errorgraph::node_id_t HdgPassthrough::getSourceNodeId() const {
-  return source_node_id_;
 }
 /*//}*/
 


### PR DESCRIPTION
## Summary
- **What changed**: 
    - Added default values _"HwAPIManager"_ into the errorgraph correction estimators.
    - Removed unused source/component from hdg_passthrough estimator:
        - **HdgPassthrough** never actually publishes a "waiting for source" error,
only **addOneshotError** on init failure. It never calls **addWaitingForNodeError**(source_node_id_) or similar
- **Why**:
    - All the correction estimators where just using the same _"HwApiManager"_ as the source node for errorgraph, and the corrections come from HwApiManager, so the default makes sense. 
- **Notes for reviewers**:

  This issue was found after the unstable [buildfarm](https://github.com/ctu-mrs/buildfarm2/actions/runs/24765535606/job/72459087123#step:4:2031), were the example estimator was not loading the parameter. With the default value this should be fixed now. 
  
  

## Impact
- **Affected areas**: Estimators, low impact given that is a new feature. But should fix the unstable build
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build
    * [x]  Test passes
    * [x] Tested in simulation
    * [] Tested on real HW