### PR TITLE
Fix/errorgraph reporting

### DIFF
--- a/include/mrs_uav_state_estimators/estimators/altitude/alt_generic.h
+++ b/include/mrs_uav_state_estimators/estimators/altitude/alt_generic.h
@@ -161,7 +161,7 @@ public:
 
   std::string getNamespacedName() const;
 
-  std::string getPrintName() const;
+  std::string getPrintName() const override;
 };
 } // namespace mrs_uav_state_estimators
 

--- a/include/mrs_uav_state_estimators/estimators/heading/hdg_generic.h
+++ b/include/mrs_uav_state_estimators/estimators/heading/hdg_generic.h
@@ -157,7 +157,7 @@ public:
 
   std::string getNamespacedName() const;
 
-  std::string getPrintName() const;
+  std::string getPrintName() const override;
 };
 } // namespace mrs_uav_state_estimators
 

--- a/include/mrs_uav_state_estimators/estimators/heading/hdg_passthrough.h
+++ b/include/mrs_uav_state_estimators/estimators/heading/hdg_passthrough.h
@@ -120,7 +120,7 @@ public:
 
   std::string getNamespacedName() const;
 
-  std::string getPrintName() const;
+  std::string getPrintName() const override;
 };
 } // namespace mrs_uav_state_estimators
 

--- a/include/mrs_uav_state_estimators/estimators/lateral/lat_generic.h
+++ b/include/mrs_uav_state_estimators/estimators/lateral/lat_generic.h
@@ -160,7 +160,7 @@ public:
 
   std::string getNamespacedName() const;
 
-  std::string getPrintName() const;
+  std::string getPrintName() const override;
 };
 } // namespace mrs_uav_state_estimators
 

--- a/src/estimators/state/state_generic.cpp
+++ b/src/estimators/state/state_generic.cpp
@@ -231,13 +231,13 @@ bool StateGeneric::start(void) {
       return true;
     } else {
       if (!est_lat_start_successful) {
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_lat_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_lat_->getPrintName()});
       }
       if (!est_alt_start_successful) {
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_->getPrintName()});
       }
       if (!est_hdg_start_successful) {
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_hdg_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_hdg_->getPrintName()});
       }
     }
 
@@ -320,13 +320,13 @@ void StateGeneric::timerUpdate() {
         RCLCPP_INFO_THROTTLE(node_->get_logger(), *clock_, 1000, "[%s]: %s subestimators to be initialized", getPrintName().c_str(),
                              Support::waiting_for_string.c_str());
         if (!est_lat_->isInitialized()) {
-          error_publisher_->addWaitingForNodeError({"EstimationManager", est_lat_->getName()});
+          error_publisher_->addWaitingForNodeError({"EstimationManager", est_lat_->getPrintName()});
         }
         if (!est_alt_->isInitialized()) {
-          error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_->getName()});
+          error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_->getPrintName()});
         }
         if (!est_hdg_->isInitialized()) {
-          error_publisher_->addWaitingForNodeError({"EstimationManager", est_hdg_->getName()});
+          error_publisher_->addWaitingForNodeError({"EstimationManager", est_hdg_->getPrintName()});
         }
         return;
       }
@@ -357,13 +357,13 @@ void StateGeneric::timerUpdate() {
       changeState(RUNNING_STATE);
     } else {
       if (!est_lat_->isRunning()) {
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_lat_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_lat_->getPrintName()});
       }
       if (!est_alt_->isRunning()) {
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_alt_->getPrintName()});
       }
       if (!est_hdg_->isRunning()) {
-        error_publisher_->addWaitingForNodeError({"EstimationManager", est_hdg_->getName()});
+        error_publisher_->addWaitingForNodeError({"EstimationManager", est_hdg_->getPrintName()});
       }
       return;
     }


### PR DESCRIPTION
## Summary
- **What changed**:
    Add **override** to `ChildEstimator::getPrintName()` method, used to provide the specific estimator error
- **Why**:
    Described in detail in https://github.com/ctu-mrs/mrs_uav_managers/pull/35

## Impact
- **Affected areas**: Errorgraph reporting
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW



